### PR TITLE
Support OTP-21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: erlang
 otp_release:
+  - 21.0
   - 20.3
   - 19.3
   - 18.3

--- a/include/moyo_internal.hrl
+++ b/include/moyo_internal.hrl
@@ -1,0 +1,7 @@
+-ifdef('FUN_STACKTRACE').
+-define(CAPTURE_STACKTRACE, ).
+-define(GET_STACKTRACE, erlang:get_stacktrace()).
+-else.
+-define(CAPTURE_STACKTRACE, :__StackTrace).
+-define(GET_STACKTRACE, __StackTrace).
+-endif.

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,8 @@
 %% erlangのコンパイルオプション.
 {erl_opts, [
             warnings_as_errors,
-            warn_untyped_record
+            warn_untyped_record,
+            {platform_define, "^(R|1|20)", 'FUN_STACKTRACE'}
            ]}.
 
 

--- a/src/moyo_file.erl
+++ b/src/moyo_file.erl
@@ -4,6 +4,7 @@
 -module(moyo_file).
 
 -include_lib("kernel/include/file.hrl").
+-include("moyo_internal.hrl").
 
 %%----------------------------------------------------------------------------------------------------------------------
 %% Exported API
@@ -98,7 +99,7 @@ get_disk_usage_async(Path, Pid, Tag) ->
                           try
                               get_disk_usage(Path)
                           catch
-                              Class:Reason -> {error, {Class, Reason, erlang:get_stacktrace()}}
+                              Class:Reason ?CAPTURE_STACKTRACE -> {error, {Class, Reason, ?GET_STACKTRACE}}
                           end,
                       Pid ! {Tag, Result}
               end),

--- a/src/moyo_fun.erl
+++ b/src/moyo_fun.erl
@@ -3,6 +3,8 @@
 %% @doc 関数に関する処理を集めたユーティリティモジュール.
 -module(moyo_fun).
 
+-include("moyo_internal.hrl").
+
 %%----------------------------------------------------------------------------------------------------------------------
 %% Exported API
 %%----------------------------------------------------------------------------------------------------------------------
@@ -64,8 +66,8 @@ try_apply(Module, Function, Args) ->
     try
         apply(Module, Function, Args)
     catch
-        Class:Reason ->
-            {error, {'EXIT', {Class, Reason, erlang:get_stacktrace()}}}
+        Class:Reason ?CAPTURE_STACKTRACE ->
+            {error, {'EXIT', {Class, Reason, ?GET_STACKTRACE}}}
     end.
 
 %% @doc 指定された関数を実行する. 実行中に例外が発生した場合は`ErrorResult'を返す
@@ -87,8 +89,8 @@ try_call(Fun) ->
     try
         Fun()
     catch
-        Class:Reason ->
-            {error, {'EXIT', {Class, Reason, erlang:get_stacktrace()}}}
+        Class:Reason ?CAPTURE_STACKTRACE ->
+            {error, {'EXIT', {Class, Reason, ?GET_STACKTRACE}}}
     end.
 
 %% @doc 引数の関数を実行する. 実行中に例外が発生した場合は`ErrorResult'を返す

--- a/src/moyo_list.erl
+++ b/src/moyo_list.erl
@@ -3,6 +3,8 @@
 %% @doc リストに関する処理を集めたユーティリティモジュール.
 -module(moyo_list).
 
+-include("moyo_internal.hrl").
+
 %%----------------------------------------------------------------------------------------------------------------------
 %% Exported API
 %%----------------------------------------------------------------------------------------------------------------------
@@ -413,7 +415,8 @@ pmap_call(Fun ,Arg) ->
             SomeResult      -> {error, {'EXIT', SomeResult}}
         end
     catch
-        ExceptionClass:SomeReason -> {error, {'EXIT', ExceptionClass, SomeReason, erlang:get_stacktrace()}}
+        ExceptionClass:SomeReason ?CAPTURE_STACKTRACE ->
+            {error, {'EXIT', ExceptionClass, SomeReason, ?GET_STACKTRACE}}
     end.
 
 -spec pmap_receive(Ref, {Count, Results}) -> Results when

--- a/src/moyo_pipe.erl
+++ b/src/moyo_pipe.erl
@@ -5,6 +5,8 @@
 %% 現在は出力機能にのみ対応済み
 -module(moyo_pipe).
 
+-include("moyo_internal.hrl").
+
 %%----------------------------------------------------------------------------------------------------------------------
 %% Exported API
 %%----------------------------------------------------------------------------------------------------------------------
@@ -100,13 +102,13 @@ output_loop(State) ->
                     try
                         true = port_command(Port, Data)
                     catch
-                        error:badarg ->
+                        error:badarg ?CAPTURE_STACKTRACE ->
                             case erlang:port_info(Port) of
                                 undefined ->
                                     %% ポートが閉じている(コマンドの実行が終了している)ので、出力プロセスも終了
                                     exit(normal);
                                 _ ->
-                                    erlang:raise(error, badarg, erlang:get_stacktrace())
+                                    erlang:raise(error, badarg, ?GET_STACKTRACE)
                             end
                     end,
                     ok = timer:sleep(Interval),


### PR DESCRIPTION
I added support for new get_stacktrace syntax of OTP-21.

The change is similar to https://github.com/sile/jsone/commit/42125d3c96ad138683221b29a1c80b7c6b23b149