### PR TITLE
Add open_port_module option to moyo_command:execute

### DIFF
--- a/doc/moyo_command.md
+++ b/doc/moyo_command.md
@@ -87,7 +87,7 @@ iodata_or_atom() = iodata() | atom()
 
 
 <pre><code>
-option() = <a href="#type-port_settings">port_settings()</a> | escape_all | {stdout, <a href="#type-destination_file_path">destination_file_path()</a> | stderr} | {stderr, <a href="#type-destination_file_path">destination_file_path()</a> | stdout} | discard_stderr | {timeout, <a href="#type-time">time()</a>} | {nice, integer()} | {close_function, fun((port()) -&gt; ok)} | {stdout_hook_fun, {<a href="#type-stdout_hook_fun">stdout_hook_fun()</a>, term()}}
+option() = <a href="#type-port_settings">port_settings()</a> | escape_all | {stdout, <a href="#type-destination_file_path">destination_file_path()</a> | stderr} | {stderr, <a href="#type-destination_file_path">destination_file_path()</a> | stdout} | discard_stderr | {timeout, <a href="#type-time">time()</a>} | {nice, integer()} | {close_function, fun((port()) -&gt; ok)} | {stdout_hook_fun, {<a href="#type-stdout_hook_fun">stdout_hook_fun()</a>, term()}} | {open_port_module, module()}
 </code></pre>
 
  execute/2, execute/3に指定できるオプション.
@@ -252,7 +252,8 @@ Destinationには出力ファイル先を指定する.<br />
 ● `{timeout, Time}`       : Time `ミリ秒` で処理が終わらなかった場合, タイムアウトする.<br />
 ● `{close_function, Fun}` : timeoutオプションでタイムアウトした時の処理を明示的に指定する.<br />
 ● `{stdout_hook_fun, {Fun, Init}}` : 標準出力をフィルタリングする.
-Initに初期値を, Funは2引数の関数で第1引数に`exit`が来た場合は`binary`を返す.
+Initに初期値を, Funは2引数の関数で第1引数に`exit`が来た場合は`binary`を返す.<br />
+● `{open_port_module, Module}` : erlang:open_port/2の代わりに, 指定したモジュールのopen_port/2を使用する.
 
 <a name="reduce_parameters-1"></a>
 

--- a/src/moyo_command.erl
+++ b/src/moyo_command.erl
@@ -33,7 +33,7 @@
 %% Macros & Records & Types
 %%----------------------------------------------------------------------------------------------------------------------
 %% execute/3の第3引数に渡せるオプションの中でopen_port/2に渡さないオプションリスト.
--define(NON_OPENPORT_OPTION, [escape_all, stdout, stderr, discard_stderr, timeout, close_function, stdout_hook_fun, nice]).
+-define(NON_OPENPORT_OPTION, [escape_all, stdout, stderr, discard_stderr, timeout, close_function, stdout_hook_fun, nice, open_port_module]).
 
 %% float() -> binary()のデフォルト表記法
 -define(DEFAULT_FLOAT_NOTATION, {decimals, 4}).
@@ -59,7 +59,8 @@
                           | {stdout, destination_file_path() | stderr} | {stderr, destination_file_path() | stdout}
                           | discard_stderr
                           | {timeout, time()} | {nice, integer()} | {close_function, fun((port()) -> ok)}
-                          | {stdout_hook_fun, {stdout_hook_fun(), term()}}.
+                          | {stdout_hook_fun, {stdout_hook_fun(), term()}}
+                          | {open_port_module, module()}.
 %% execute/2, execute/3に指定できるオプション.
 -type port_settings()    :: term(). % open_portに指定できるオプション.
 -type time()             :: non_neg_integer().
@@ -362,7 +363,8 @@ execute_impl(Parent, Command, OptionList) ->
     OptionListForOpenPort = prepare_option_for_open_port(OptionList),
 
     %% 外部コマンドを実行.
-    Port = open_port({spawn, binary_to_list(Command)}, OptionListForOpenPort),
+    Module = proplists:get_value(open_port_module, OptionList, erlang),
+    Port = Module:open_port({spawn, binary_to_list(Command)}, OptionListForOpenPort),
 
     Time = proplists:get_value(timeout, OptionList),
     TimerSetting = set_timer(Time),

--- a/src/moyo_command.erl
+++ b/src/moyo_command.erl
@@ -111,6 +111,7 @@ generate_command(Command, ArgumentList) -> generate_command(Command, ArgumentLis
 %% ● `{close_function, Fun}' : timeoutオプションでタイムアウトした時の処理を明示的に指定する.<br />
 %% ● `{stdout_hook_fun, {Fun, Init}}' : 標準出力をフィルタリングする.
 %%                                      Initに初期値を, Funは2引数の関数で第1引数に`exit'が来た場合は`binary'を返す.
+%% ● `{open_port_module, Module}' : erlang:open_port/2の代わりに, 指定したモジュールのopen_port/2を使用する.
 -spec generate_command(command(), [argument()], [option()]) -> binary().
 generate_command(Command, ArgumentList, OptionList) ->
     %% escape_allオプション

--- a/src/moyo_command.erl
+++ b/src/moyo_command.erl
@@ -110,7 +110,7 @@ generate_command(Command, ArgumentList) -> generate_command(Command, ArgumentLis
 %% ● `{timeout, Time}'       : Time `ミリ秒' で処理が終わらなかった場合, タイムアウトする.<br />
 %% ● `{close_function, Fun}' : timeoutオプションでタイムアウトした時の処理を明示的に指定する.<br />
 %% ● `{stdout_hook_fun, {Fun, Init}}' : 標準出力をフィルタリングする.
-%%                                      Initに初期値を, Funは2引数の関数で第1引数に`exit'が来た場合は`binary'を返す.
+%%                                      Initに初期値を, Funは2引数の関数で第1引数に`exit'が来た場合は`binary'を返す.<br />
 %% ● `{open_port_module, Module}' : erlang:open_port/2の代わりに, 指定したモジュールのopen_port/2を使用する.
 -spec generate_command(command(), [argument()], [option()]) -> binary().
 generate_command(Command, ArgumentList, OptionList) ->

--- a/test/moyo_command_tests.erl
+++ b/test/moyo_command_tests.erl
@@ -427,7 +427,22 @@ execute_test_() ->
               Expected = {{ok, <<"alert1\nalert2\nalert3\n">>}, <<"echo \"alert1\ninfo\nalert2\nnotice\nalert3\n\"">>},
               ?assertEqual(Expected, Result)
 
-      end}
+      end},
+
+      {"open_port_moduleを指定する",
+       fun () ->
+              Result = moyo_command:execute("echo", ["test"], [{open_port_module, erlang}]),
+
+              Expected = {{ok, <<"test\n">>}, <<"echo test">>},
+              ?assertEqual(Expected, Result)
+       end},
+
+       {"open_port_moduleに不正なモジュールを指定した場合",
+        fun () ->
+              Result = moyo_command:execute("echo", ["test"], [{open_port_module, undefined_module}]),
+
+              ?assertMatch({{error, {undef, _}}, <<"echo test">>}, Result)
+        end}
     ].
 
 escape_shell_arg_test_() ->

--- a/test/moyo_command_tests.erl
+++ b/test/moyo_command_tests.erl
@@ -442,6 +442,13 @@ execute_test_() ->
               Result = moyo_command:execute("echo", ["test"], [{open_port_module, undefined_module}]),
 
               ?assertMatch({{error, {undef, _}}, <<"echo test">>}, Result)
+        end},
+
+        {"open_port_moduleにopen_port/2をexportしていないモジュールを指定した場合",
+        fun () ->
+              Result = moyo_command:execute("echo", ["test"], [{open_port_module, lists}]),
+
+              ?assertMatch({{error, {undef, _}}, <<"echo test">>}, Result)
         end}
     ].
 


### PR DESCRIPTION
I added `open_port_module` option to `moyo_command:execute` for switching module for `open_port` function from default (erlang module) to other modules. (e.g. https://github.com/sile/safeexec)