### PR TITLE
fix spec

### DIFF
--- a/src/moyo_assoc.erl
+++ b/src/moyo_assoc.erl
@@ -452,12 +452,13 @@ to_record(RecordName, Fields, Params) ->
 %% > {ok, Entries} = lookup_entries_as(FieldSpecList, Params).
 %% > to_record(RecordName, Fields, Entries).
 %% '''
--spec to_record_as(RecordName, Fields, FieldSpecList, Params) -> {ok, assoc_list()} | {error, Reason} when
+-spec to_record_as(RecordName, Fields, FieldSpecList, Params) -> {ok, Record} | {error, Reason} when
       RecordName    :: atom(),
       Fields        :: [atom()],
       FieldSpecList :: [validate_entry_spec()],
       Params        :: assoc_list(),
-      Reason        :: term().
+      Reason        :: term(),
+      Record        :: tuple().
 to_record_as(RecordName, Fields, FieldSpecList, Params) ->
     case moyo_assoc:lookup_entries_as(FieldSpecList, Params) of
         {error, Reason} -> {error, Reason};


### PR DESCRIPTION
- call `to_record_as` from other module
```
-module(hoge).
-export([hoge/0]).
-record(?MODULE,
        {hoge = hoge :: atom()}).

hoge() ->
    case moyo_assoc:to_record_as(?MODULE,
                                 [hoge],
                                 [{hoge, atom, []}],
                                 [{hoge, hoge}]) of
        {ok, State} -> State#hoge.hoge;
        {error, _} -> error
    end.
```

- run dialyzer
```
% dialyzer hoge.erl moyo_assoc.erl
  Checking whether the PLT /Users/shohei_kokubo/.dialyzer_plt is up-to-date... yes
  Proceeding with analysis...
hoge.erl:11: The pattern {'ok', State} can never match the type {'error',_}
Unknown functions:
  moyo_list:maybe_map/2
  moyo_validator:validate/3
Unknown types:
  moyo_validator:option/0
  moyo_validator:spec/0
 done in 0m0.32s
done (warnings were emitted)
```

- fix spec
```
% dialyzer hoge.erl moyo_assoc.erl
  Checking whether the PLT /Users/shohei_kokubo/.dialyzer_plt is up-to-date... yes
  Proceeding with analysis...
Unknown functions:
  moyo_list:maybe_map/2
  moyo_validator:validate/3
Unknown types:
  moyo_validator:option/0
  moyo_validator:spec/0
 done in 0m0.30s
done (passed successfully)
```