### PR TITLE
moyo_concurrent の入力の写像を返すバージョン

### DIFF
--- a/src/moyo_concurrent.erl
+++ b/src/moyo_concurrent.erl
@@ -55,7 +55,7 @@ exec(Inputs, Timeout) ->
 %% @doc 並行に複数のコマンドを実行する
 %%
 %% see: `exec_map([Input], infinity)`
--spec exec_map([Input]) -> [{Input, RetValue :: term()} | {'EXIT', Input, Signal :: term()}] when
+-spec exec_map([Input]) -> [RetValue :: term() | {'EXIT', Signal :: term()}] when
       Input   :: {module(), Function :: atom(), Args :: [term()]}.
 exec_map(Inputs) ->
     exec_map(Inputs, infinity).
@@ -63,7 +63,7 @@ exec_map(Inputs) ->
 %% @doc 並行に複数のコマンドを実行する
 %% 返り値は Inputs の順番で返される. <br />
 %% 1つでも結果がerrorだった場合もすべての実行が完了を待ち, 結果のリストは Inputs の写像となる.
--spec exec_map([Input], Timeout) -> [{Input, RetValue :: term()} | {'EXIT', Input, Signal :: term()}] when
+-spec exec_map([Input], Timeout) -> [RetValue :: term() | {'EXIT', Signal :: term()}] when
       Input   :: {module(), Function :: atom(), Args :: [term()]},
       Timeout :: timeout().
 exec_map(Inputs, Timeout) ->
@@ -119,7 +119,7 @@ exec_order_by_input(Inputs) ->
     [receive {Input, RetValue} -> RetValue end || Input <- Inputs].
 
 %% @doc Input要素の関数をプロセスを立てて実行し, 結果を入力順に返す. エラーが起きても停止しない.
--spec exec_order_preserved_by_input([Input]) -> [{Input, RetValue :: term()} | {'EXIT', Input, Signal :: term()}] when
+-spec exec_order_preserved_by_input([Input]) -> [RetValue :: term() | {'EXIT', Signal :: term()}] when
       Input :: {module(), Function :: atom(), Args :: [term()]}.
 exec_order_preserved_by_input(Inputs) ->
     Self = self(),
@@ -129,9 +129,9 @@ exec_order_preserved_by_input(Inputs) ->
                        end)
             || {Module, Fun, Args} <- Inputs],
     [receive
-         {Input, _} = Ok -> 
+         {Input, Result} ->
              receive %% wait normal exit
-                 {'EXIT', Pid, normal} -> Ok
+                 {'EXIT', Pid, normal} -> Result
              end;
-         {'EXIT', Pid, Signal} -> {'EXIT', Input, Signal}
+         {'EXIT', Pid, Signal} -> {'EXIT', Signal}
      end || {Pid, Input} <- lists:zip(Pids, Inputs)].

--- a/test/moyo_concurrent_tests.erl
+++ b/test/moyo_concurrent_tests.erl
@@ -101,9 +101,8 @@ exec_map_test_() ->
                            {{lists, reverse, [[3,4,5]]}, [5,4,3]},
                            {{lists, member,  [1, [1,2,3]]}, true}
                           ],
-               Assoc  = moyo_concurrent:exec_map([Input || {Input, _} <- TestData]),
-               [?assertEqual(Expected, moyo_assoc:fetch(Input, Assoc))
-                || {Input, Expected} <- TestData]
+               Actual  = moyo_concurrent:exec_map([Input || {Input, _} <- TestData]),
+               ?assertEqual(Actual, [E || {_, E} <- TestData])
        end},
       {"Input が同じ場合",
        fun() ->
@@ -119,10 +118,8 @@ exec_map_test_() ->
                            {{lists, reverse, [[1,2,3]]}, [3,2,1]},
                            {{lists, reverse, [[1,2,3]]}, [3,2,1]},
                            {{lists, reverse, [[x,y,z]]}, [z,y,x]}],
-               Assoc  = moyo_concurrent:exec_map([Input || {Input, _} <- TestData]),
-               %% order sensitive 
-               [?assertEqual(lists:nth(I, TestData), lists:nth(I, Assoc))
-                || I <- lists:seq(1, length(TestData))]
+               Actual = moyo_concurrent:exec_map([Input || {Input, _} <- TestData]),
+               ?assertEqual(Actual, [E || {_, E} <- TestData])
        end},
       {"error, throw, exit になるものがある場合",
        fun() ->
@@ -133,11 +130,11 @@ exec_map_test_() ->
                         {erlang, exit, [piyo]}],
                Result = moyo_concurrent:exec_map(Input),
                %% order sensitive
-               ?assertEqual({{lists, reverse, [[1, 2, 3]]}, [3, 2, 1]}, lists:nth(1, Result)),
-               ?assertEqual({{lists, reverse, [[3, 4, 5]]}, [5, 4, 3]}, lists:nth(2, Result)),
-               ?assertMatch2({'EXIT', {erlang, error, [hoge]}, {hoge, _}}, lists:nth(3, Result)),
-               ?assertMatch2({'EXIT', {erlang, throw, [fuga]}, {{nocatch, fuga}, _}}, lists:nth(4, Result)),
-               ?assertMatch2({'EXIT', {erlang, exit, [piyo]}, piyo}, lists:nth(5, Result))
+               ?assertEqual([3, 2, 1], lists:nth(1, Result)),
+               ?assertEqual([5, 4, 3], lists:nth(2, Result)),
+               ?assertMatch2({'EXIT', {hoge, _}}, lists:nth(3, Result)),
+               ?assertMatch2({'EXIT', {{nocatch, fuga}, _}}, lists:nth(4, Result)),
+               ?assertMatch2({'EXIT', piyo}, lists:nth(5, Result))
        end},
       {"signal が突き抜けない",
        fun() ->
@@ -146,7 +143,7 @@ exec_map_test_() ->
                                                  ok
                                          end, []]}],
                Result = moyo_concurrent:exec_map(Input),
-               ?assertMatch2([{{erlang, apply, _}, ok}], Result)
+               ?assertMatch2([ok], Result)
        end}
      ]}.
 


### PR DESCRIPTION
moyo_concurrent:exec_map() は Inputs のいずれかがエラーになっても全体を終了させない exec のバージョンです。
map(Inputs) -> Outputs のとき Outputs の各要素は Inputs の同じ位置の Input に対応します。

エラーになった場合は Input::{M,F,A} の返り値がリストに入る代わりに {'EXIT', <s>Input,</s> Signal} が入ります。
