### PR TITLE
moyo_concurrent:exec_order_by_input を修正

### DIFF
--- a/src/moyo_concurrent.erl
+++ b/src/moyo_concurrent.erl
@@ -126,13 +126,13 @@ exec_order_preserved_by_input(Inputs) ->
     process_flag(trap_exit, true),
     Indices = lists:seq(1, length(Inputs)),
     Pids = [spawn_link(fun() ->
-                               Self ! {Index, {Module, Fun, Args}, apply(Module, Fun, Args)}
+                               Self ! {Index, apply(Module, Fun, Args)}
                        end)
             || {Index, {Module, Fun, Args}} <- lists:zip(Indices, Inputs)],
     [receive
-         {Index, Input, Result} ->
+         {Index, Result} ->
              receive %% wait normal exit
                  {'EXIT', Pid, normal} -> Result
              end;
          {'EXIT', Pid, Signal} -> {'EXIT', Signal}
-     end || {Index, {Pid, Input}} <- lists:zip(Indices, lists:zip(Pids, Inputs))].
+     end || {Index, Pid} <- lists:zip(Indices, Pids)].

--- a/src/moyo_concurrent.erl
+++ b/src/moyo_concurrent.erl
@@ -124,14 +124,15 @@ exec_order_by_input(Inputs) ->
 exec_order_preserved_by_input(Inputs) ->
     Self = self(),
     process_flag(trap_exit, true),
+    Indices = lists:seq(1, length(Inputs)),
     Pids = [spawn_link(fun() ->
-                               Self ! {{Module, Fun, Args}, apply(Module, Fun, Args)}
+                               Self ! {Index, {Module, Fun, Args}, apply(Module, Fun, Args)}
                        end)
-            || {Module, Fun, Args} <- Inputs],
+            || {Index, {Module, Fun, Args}} <- lists:zip(Indices, Inputs)],
     [receive
-         {Input, Result} ->
+         {Index, Input, Result} ->
              receive %% wait normal exit
                  {'EXIT', Pid, normal} -> Result
              end;
          {'EXIT', Pid, Signal} -> {'EXIT', Signal}
-     end || {Pid, Input} <- lists:zip(Pids, Inputs)].
+     end || {Index, {Pid, Input}} <- lists:zip(Indices, lists:zip(Pids, Inputs))].

--- a/test/moyo_concurrent_tests.erl
+++ b/test/moyo_concurrent_tests.erl
@@ -102,7 +102,7 @@ exec_map_test_() ->
                            {{lists, member,  [1, [1,2,3]]}, true}
                           ],
                Actual  = moyo_concurrent:exec_map([Input || {Input, _} <- TestData]),
-               ?assertEqual(Actual, [E || {_, E} <- TestData])
+               ?assertEqual([E || {_, E} <- TestData], Actual)
        end},
       {"Input が同じ場合",
        fun() ->
@@ -119,7 +119,7 @@ exec_map_test_() ->
                            {{lists, reverse, [[1,2,3]]}, [3,2,1]},
                            {{lists, reverse, [[x,y,z]]}, [z,y,x]}],
                Actual = moyo_concurrent:exec_map([Input || {Input, _} <- TestData]),
-               ?assertEqual(Actual, [E || {_, E} <- TestData])
+               ?assertEqual([E || {_, E} <- TestData], Actual)
        end},
       {"error, throw, exit になるものがある場合",
        fun() ->


### PR DESCRIPTION
引数が全く同じ時に、順番がバラバラになっていて CI が落ちていた (https://travis-ci.org/dwango/moyo/jobs/623770470?utm_medium=notification&utm_source=github_status) ので、修正しました。