### PR TITLE
`moyo_assoc:to_map_recur/1` 内の `error` 関数に引数情報を追加

### DIFF
--- a/src/moyo_assoc.erl
+++ b/src/moyo_assoc.erl
@@ -694,9 +694,9 @@ to_map_recur(NestAssocList)  ->
         is_list(NestAssocList) ->
             case to_map_recur_any(NestAssocList) of
                 Res when (is_map(Res)) -> Res;
-                _ -> error(badarg)
+                _ -> error(badarg, [NestAssocList])
             end;
-        true -> error(badarg)
+        true -> error(badarg, [NestAssocList])
     end.
 
 %%----------------------------------------------------------------------------------------------------------------------

--- a/test/moyo_assoc_tests.erl
+++ b/test/moyo_assoc_tests.erl
@@ -869,5 +869,9 @@ to_map_recur_test_() ->
         {"Keyが同じなら前の値で変換される",
             fun() ->
                 ?assertEqual(#{1=>#{1=>2}}, moyo_assoc:to_map_recur([{1, [{1, 2}, {1, 3}]}, {1, 3}]))
+            end},
+        {"入力が不正な場合はエラーとなる",
+            fun() ->
+                ?assertError(badarg, moyo_assoc:to_map_recur(hoge))
             end}
     ].


### PR DESCRIPTION
`moyo_assoc:to_map_recur/1` 内の `error` 関数に引数情報を追加します。現状の同関数内では `error/1` が使用されており `badarg` 例外の送出時に引数情報を得ることができません。`badarg` 例外の送出時に引数情報を得られれば、後のデバッグに役立ちます。

修正前

```erlang
1> moyo_assoc:to_map_recur(hoge).
** exception error: bad argument
     in function  moyo_assoc:to_map_recur/1 (.../moyo/_build/default/lib/moyo/src/moyo_assoc.erl, line 699)```
```

修正後

```erlang
1> moyo_assoc:to_map_recur(hoge).                            
** exception error: bad argument
     in function  moyo_assoc:to_map_recur/1
        called as moyo_assoc:to_map_recur(hoge)
```

おまけで `badarg` 時のテストを追加しました。これはこのPRの修正前のヴァージョンも通します。