### PR TITLE
OTP 更新に対応

### DIFF
--- a/include/eunit.hrl
+++ b/include/eunit.hrl
@@ -17,24 +17,24 @@
 -define(assertMatch2(Guard, Expr),
         (fun() ->
                  try
-                     __MOYO_ASSERT_MATCH2_TMP = Expr,
+                     MOYO_ASSERT___MATCH2_TMP = Expr,
 
                      %% `Guard'内に変数が含まれる場合に、OTP18で"unused変数警告"が出力されるのを抑制するために、二度`Guard'を使っている。
                      %% (一度目で束縛された変数が、二度目は使われるので警告がでなくなる)
                      %%
-                     %% なお`Guard = Guard = __MOYO_ASSERT_MATCH2_TMP'のようにまとめて書くと、`Guard'にバイナリリテラルが含まれる場合に、
+                     %% なお`Guard = Guard = MOYO_ASSERT___MATCH2_TMP'のようにまとめて書くと、`Guard'にバイナリリテラルが含まれる場合に、
                      %% OTP18で別のコンパイラ警告が出てしまうので、別々に分けている。
-                     Guard = __MOYO_ASSERT_MATCH2_TMP,
-                     Guard = __MOYO_ASSERT_MATCH2_TMP,
+                     Guard = MOYO_ASSERT___MATCH2_TMP,
+                     Guard = MOYO_ASSERT___MATCH2_TMP,
                      ok
                  catch
-                     error:{badmatch, __MOYO_EUNIT_V} ->
+                     error:{badmatch, MOYO_EUNIT___V} ->
                          erlang:error({assertMatch_failed,
                                        [{module, ?MODULE},
                                         {line, ?LINE},
                                         {expression, (??Expr)},
                                         {pattern, (??Guard)},
-                                        {value, (__MOYO_EUNIT_V)}
+                                        {value, (MOYO_EUNIT___V)}
                                        ]})
                  end
          end)()).
@@ -50,9 +50,9 @@
 -define(assignMatch(Guard, Expr),
         begin
             Guard = (fun() ->
-                             __MOYO_EUNIT_TMP = Expr,
-                             ?assertMatch2(Guard, __MOYO_EUNIT_TMP),
-                             __MOYO_EUNIT_TMP
+                             MOYO_EUNIT___TMP = Expr,
+                             ?assertMatch2(Guard, MOYO_EUNIT___TMP),
+                             MOYO_EUNIT___TMP
                      end)()
         end).
 -endif.
@@ -69,8 +69,8 @@
 -define(assertTerminated(Pid, Reason),
         (fun() ->
                  receive
-                     {'EXIT', Pid, __MOYO_EUNIT_RetReason} ->
-                         ?assertMatch2(Reason, __MOYO_EUNIT_RetReason)
+                     {'EXIT', Pid, MOYO_EUNIT___RetReason} ->
+                         ?assertMatch2(Reason, MOYO_EUNIT___RetReason)
                  after 3000 ->
                          ?assert(timeout)
                  end
@@ -91,8 +91,8 @@
 -define(assertDown(Ref, Reason),
         (fun() ->
                  receive
-                     {'DOWN', Ref, process, _, __MOYO_EUNIT_RetReason} ->
-                         ?assertMatch2(Reason, __MOYO_EUNIT_RetReason)
+                     {'DOWN', Ref, process, _, MOYO_EUNIT___RetReason} ->
+                         ?assertMatch2(Reason, MOYO_EUNIT___RetReason)
                  after 3000 ->
                          ?assert(timeout)
                  end
@@ -137,12 +137,12 @@
 -else.
 -define(ensureExited(Pid, Reason),
         (fun() ->
-                 __MOYO_EUNIT_Pid = Pid,
-                 __MOYO_EUNIT_Old = process_flag(trap_exit, true),
-                 __MOYO_EUNIT_Ref = monitor(process, __MOYO_EUNIT_Pid),
-                 exit(__MOYO_EUNIT_Pid, Reason),
-                 ?assertDown(__MOYO_EUNIT_Ref, _),
-                 process_flag(trap_exit, __MOYO_EUNIT_Old)
+                 MOYO_EUNIT___Pid = Pid,
+                 MOYO_EUNIT___Old = process_flag(trap_exit, true),
+                 MOYO_EUNIT___Ref = monitor(process, MOYO_EUNIT___Pid),
+                 exit(MOYO_EUNIT___Pid, Reason),
+                 ?assertDown(MOYO_EUNIT___Ref, _),
+                 process_flag(trap_exit, MOYO_EUNIT___Old)
          end)()).
 -endif.
 -define(_ensureExited(Pid, Reason), ?_test(?ensureExited(Pid, Reason))).
@@ -163,8 +163,8 @@
 -else.
 -define(assertLinked(Pid1, Pid2),
         (fun () ->
-                 {_, __Links} = erlang:process_info(Pid2, links),
-                 ?assert(lists:member(Pid1, __Links))
+                 {_, MOYO__Links} = erlang:process_info(Pid2, links),
+                 ?assert(lists:member(Pid1, MOYO__Links))
          end)()).
 -endif.
 -define(_assertLinked(Pid1, Pid2), ?_test(?assertLinked(Pid1, Pid2))).

--- a/rebar.config
+++ b/rebar.config
@@ -40,7 +40,7 @@
 {dialyzer,
  [
   {plt_extra_apps, [eunit]},
-  {warnings, [error_handling, race_conditions, unmatched_returns, unknown, no_improper_lists]}
+  {warnings, [error_handling, unmatched_returns, unknown, no_improper_lists]}
 ]}.
 
 {ct_dirs, "ct"}.

--- a/src/moyo_list.erl
+++ b/src/moyo_list.erl
@@ -117,7 +117,7 @@ position_if(PredFun, List) -> position_if_impl(PredFun, List, 1).
 
 %% @doc 入力リストの順番を無作為に並べ替える
 -spec shuffle([Element]) -> [Element] when Element :: term().
-shuffle(List) ->
+shuffle(List) when is_list(List) ->
     [E || {_, E} <- lists:ukeysort(1, [{rand:uniform(), E} || E <- List])].
 
 %% @doc lists:foldl/3 の中断機能追加版: 関数適用後の結果が`{false, _}'となった場合は、そこで走査が中断される.


### PR DESCRIPTION
以下の3点に対応

- "__" で始まる変数が OTP 24 で束縛済みという警告が出るようになったので対応 (*1)
- リスト内包表記で生成式が不正な時に bad_generator エラーが出るようになったので、 moyo_list:shuffle/1 で従来通り function_clause が返るように変更
- OTP 25 で dialyzer の race_conditions オプションが廃止されたので削除

*1: 普通の変数なら問題ないが "__" で始まる変数で警告が出る例
```
$ cat bound.erl && echo '-----' && erlc bound.erl
-module(bound).

-export([normal/0, underscore/0]).

normal() ->
    A = 1,
    A = 1,
    ok.

underscore() ->
    __A = 1,
    __A = 1,
    ok.
-----
bound.erl:12:5: Warning: variable '__A' is already bound. If you mean to ignore this value, use '_' or a different underscore-prefixed name
%   12|     __A = 1,
%     |     ^
```