### PR TITLE
OTP 27 向けに浮動小数点数ゼロのマッチを改善

### DIFF
--- a/src/moyo_frac.erl
+++ b/src/moyo_frac.erl
@@ -88,7 +88,7 @@ from_integer(Int) -> #fraction{numerator = Int, denominator = 1}.
 %% 非正規化数を分数にすることはできるが, to_floatすると割り算でerrorが発生する.
 %% 無限大, NaNに関してはErlangのfloatでは使えないので考慮していない.
 -spec from_float(float()) -> fraction().
-from_float(0.0) ->
+from_float(Float) when Float =:= +0.0 orelse Float =:= -0.0 ->
     moyo_frac:new(0, 1);
 from_float(Float) ->
     <<MaybeSign:1, MaybeExponent:11, MaybeFraction:52>> = <<Float/float>>,


### PR DESCRIPTION
OTP 27 からは `0.0` は `-0.0` にマッチしなくなる。
そのため `0.0` でマッチ等をしていて影響を受ける可能性の出る箇所が OTP 26.1 から警告がでるようになった。
see: https://www.erlang.org/doc/general_info/upcoming_incompatibilities#0.0-and--0.0-will-no-longer-be-exactly-equal

この PR では警告の出た箇所について明示的に `+0.0` および `-0.0` と比較することで警告を回避する。