### PR TITLE
OTP 27 向けに moyo_monad:maybe をリネーム

### DIFF
--- a/src/moyo_monad.erl
+++ b/src/moyo_monad.erl
@@ -8,19 +8,19 @@
 %%----------------------------------------------------------------------------------------------------------------------
 -export([
          apply_maybe/3,
-         maybe/1,
+         maybe_val/1,
          maybe_fun/1
         ]).
 
 -export_type([
-              maybe/0,
+              maybe_val/0,
               maybe_fun/0
              ]).
 
 %%----------------------------------------------------------------------------------------------------------------------
 %% Types
 %%----------------------------------------------------------------------------------------------------------------------
--type maybe() :: {just, term()} | nothing.
+-type maybe_val() :: {just, term()} | nothing.
 %% なにか or Nothing を格納するデータ構造
 -type maybe_fun() :: {just, fun()} | nothing.
 %% 何らかの関数 or Nothing を格納するデータ構造
@@ -28,16 +28,16 @@
 %%----------------------------------------------------------------------------------------------------------------------
 %% Exported Functions
 %%----------------------------------------------------------------------------------------------------------------------
-%% @doc maybe()を作ります.
+%% @doc maybe_val()を作ります.
 %%
 %% {just nothing} は作れないので直接作ってください.
--spec maybe(term()) -> maybe().
-maybe(nothing) -> nothing;
-maybe(Value) -> {just, Value}.
+-spec maybe_val(term()) -> maybe_val().
+maybe_val(nothing) -> nothing;
+maybe_val(Value) -> {just, Value}.
 
 
 %% @doc maybe()を作ります.
--spec maybe_fun(nothing | fun()) -> maybe().
+-spec maybe_fun(nothing | fun()) -> maybe_val().
 maybe_fun(nothing) -> nothing;
 maybe_fun(Fun) when is_function(Fun) -> {just, Fun};
 maybe_fun(Fun) -> error({invalid_function, Fun}).

--- a/test/moyo_cond_tests.erl
+++ b/test/moyo_cond_tests.erl
@@ -7,11 +7,11 @@ apply_if_test_() ->
     [
      {"条件節の値がtrueの場合は、THEN節で渡した関数が実行される",
       fun () ->
-              ?assertEqual(then, moyo_cond:apply_if(true, fun () -> then end, fun () -> else end))
+              ?assertEqual('then', moyo_cond:apply_if(true, fun () -> 'then' end, fun () -> 'else' end))
       end},
      {"条件節の値がfalseの場合は、ELSE節で渡した関数が実行される",
       fun () ->
-              ?assertEqual(else, moyo_cond:apply_if(false, fun () -> then end, fun () -> else end))
+              ?assertEqual('else', moyo_cond:apply_if(false, fun () -> 'then' end, fun () -> 'else' end))
       end}
     ].
 

--- a/test/moyo_monad_tests.erl
+++ b/test/moyo_monad_tests.erl
@@ -5,10 +5,10 @@
 
 maybe_constructor_test_() ->
     [
-     {"maybe, maybe_funを作る",
+     {"maybe_val, maybe_funを作る",
       fun () ->
-              ?assertEqual(nothing, moyo_monad:maybe(nothing)),
-              ?assertEqual({just, 123}, moyo_monad:maybe(123)),
+              ?assertEqual(nothing, moyo_monad:maybe_val(nothing)),
+              ?assertEqual({just, 123}, moyo_monad:maybe_val(123)),
               ?assertEqual(nothing, moyo_monad:maybe_fun(nothing)),
               SomeFun = fun(A, B)->A+B end,
               ?assertEqual({just, SomeFun}, moyo_monad:maybe_fun(SomeFun)),


### PR DESCRIPTION
OTP 27 ではデフォルトで `maybe` 式が有効になるため `moyo_monad:maybe` がコンパイルエラーを起こすようになる。

この PR では `moyo_monad:maybe_val` にリネームする。

注意: この変更は既存の moyo_monad 利用箇所の互換性を破壊する。