### PR TITLE
テストでの open_port/2 の利用法間違いを修正

### DIFF
--- a/test/moyo_binary_tests.erl
+++ b/test/moyo_binary_tests.erl
@@ -311,7 +311,7 @@ to_binary_test_() ->
       end},
      {"ポートを文字列に変換",
       fun () ->
-              Input = open_port("ls", []),
+              Input = open_port({spawn, "ls"}, []),
               ?assert(is_binary(moyo_binary:to_binary(Input))) % 具体的な文字列表現は環境依存なのでテストしない
       end},
      {"リファレンスを文字列に変換",

--- a/test/moyo_string_tests.erl
+++ b/test/moyo_string_tests.erl
@@ -81,7 +81,7 @@ to_string_test_() ->
       end},
      {"ポートを文字列に変換",
       fun () ->
-              Input = open_port("ls", []),
+              Input = open_port({spawn, "ls"}, []),
               ?assert(is_list(moyo_string:to_string(Input))) % 具体的な文字列表現は環境依存なのでテストしない
       end},
      {"リファレンスを文字列に変換",


### PR DESCRIPTION
`erlang:open_port/2` に `string()` を直接渡すのは間違っているので `{spawn, string()}` の形に修正。